### PR TITLE
Fixed spelling of host_name param in docs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,7 +40,7 @@
 #          the SSL certificates settings below.
 # Default: false
 #
-# [*hostname*]
+# [*host_name*]
 # Value  : A meaningful host name to be displayed in the user interface. On
 #          many cloud based nodes the host name is incomprehensible and makes
 #          finding a specific host problematic. Using this option will allow


### PR DESCRIPTION
As it says on the tin.