### PR TITLE
Fix a warning about loglevel metaparameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@
 #          required in order for the server monitor to start.
 # Default: none
 #
-# [*loglevel*]
+# [*log_level*]
 # Value  : Level of detail you want in the log file (as defined by the logfile
 #          setting below. Valid values are (in increasing levels of verbosity):
 #          error        - show errors only
@@ -273,7 +273,7 @@
 #
 class newrelic (
   $license_key         = params_lookup( 'license_key' ),
-  $loglevel            = params_lookup( 'loglevel' ),
+  $log_level           = params_lookup( 'log_level' ),
   $proxy               = params_lookup( 'proxy' ),
   $ssl_enable          = params_lookup( 'ssl_enable' ),
   $host_name           = params_lookup( 'host_name' ),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,7 @@ class newrelic::params {
 
   ### Module specific parameters
   $license_key = 'none'
-  $loglevel = 'info'
+  $log_level = 'info'
   $proxy = ''
   $ssl_enable = false
   $collector_host = 'collector.newrelic.com'

--- a/templates/nrsysmond.cfg.erb
+++ b/templates/nrsysmond.cfg.erb
@@ -28,7 +28,7 @@ license_key=<%= scope.lookupvar('newrelic::license_key') %>
 # Default: error
 # Note   : Can also be set with the -d command line option.
 #
-loglevel=<%= scope.lookupvar('newrelic::loglevel') %>
+loglevel=<%= scope.lookupvar('newrelic::log_level') %>
 
 #
 # Option : logfile


### PR DESCRIPTION
"Warning: loglevel is a metaparam; this value will inherit to all contained resources in the newrelic definition"

https://docs.puppetlabs.com/references/latest/metaparameter.html#loglevel
